### PR TITLE
Fix test and update ktor version

### DIFF
--- a/rest/src/test/kotlin/request/MessageRequests.kt
+++ b/rest/src/test/kotlin/request/MessageRequests.kt
@@ -1,70 +1,74 @@
 package dev.kord.rest.request
 
+import dev.kord.common.entity.DiscordAttachment
+import dev.kord.common.entity.DiscordMessage
+import dev.kord.common.entity.DiscordUser
+import dev.kord.common.entity.MessageType.Default
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.service.ChannelService
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
-import io.ktor.util.cio.*
-import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.MethodOrderer
+import kotlinx.datetime.Clock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestMethodOrder
-import kotlin.io.path.toPath
 
-@TestMethodOrder(MethodOrderer.MethodName::class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+private val mockId = Snowflake(42)
+private const val fileName = "linus.png"
+private val mockMessage = DiscordMessage(
+    id = mockId,
+    channelId = mockId,
+    author = DiscordUser(id = mockId, username = "user", discriminator = "1337", avatar = null),
+    content = "",
+    timestamp = Clock.System.now(),
+    editedTimestamp = null,
+    tts = false,
+    mentionEveryone = false,
+    mentions = emptyList(),
+    mentionRoles = emptyList(),
+    attachments = listOf(
+        DiscordAttachment(
+            id = mockId,
+            filename = fileName,
+            size = 1234,
+            url = "http://never.gonna.give.you.up",
+            proxyUrl = "http://never.gonna.let.you.down",
+        )
+    ),
+    embeds = emptyList(),
+    pinned = false,
+    type = Default,
+)
+
 class MessageRequests {
     @Test
-    fun `attachment channel closed`() = runBlocking {
-        val mockEngine = MockEngine {
-            respond(
-                content = ByteReadChannel("""{
-                    "id": "1234", 
-                    "type": 0,
-                    "content": "FOO", 
-                    "channel_id": "1234", 
-                    "author": {
-                        "id": "1234", 
-                        "username": "Bar", 
-                        "avatar": null, 
-                        "discriminator": "1337"
-                    }, 
-                    "attachments": [ 
-                        {
-                            "id": "1234", 
-                            "filename": "linus.png",
-                            "size": 1234,
-                            "url": "http://never.gonna.give.you.up",
-                            "proxy_url": "http://never.gonna.let.you.down"
-                        } 
-                    ], 
-                    "embeds": [], 
-                    "mentions": [], 
-                    "mention_roles": [], 
-                    "pinned": false, 
-                    "mention_everyone": false, 
-                    "tts": false, 
-                    "timestamp": "1987-07-27T12:00:00.000000+00:00", 
-                    "edited_timestamp": null 
-                }""".trimIndent().encodeToByteArray())
-            )
+    fun `attachment channel is read and closed lazily`() = runBlocking {
+
+        val mockEngine = MockEngine { request ->
+            request.body.toByteArray() // `toByteArray()` reads `fileChannel`
+
+            respond(Json.encodeToString(mockMessage))
         }
 
-        val client = HttpClient(mockEngine)
-        val handler = KtorRequestHandler(client = client, token = "")
-        val service = ChannelService(handler)
+        val channelService = ChannelService(KtorRequestHandler(client = HttpClient(mockEngine), token = ""))
 
-        val readChannel = ClassLoader.getSystemResource("images/kord.png").toURI().toPath().readChannel()
-        readChannel.awaitContent()
+        val fileChannel = ClassLoader.getSystemResourceAsStream("images/kord.png")!!.toByteReadChannel()
 
-        assert(!readChannel.isClosedForWrite)
+        with(fileChannel) {
+            assert(!isClosedForWrite)
+            assert(!isClosedForRead)
+            assert(totalBytesRead == 0L)
 
-        service.createMessage(Snowflake(0)) {
-            addFile("linus.png", readChannel)
+            val createdMessage = channelService.createMessage(mockId) {
+                addFile(fileName, fileChannel)
+            }
+            assert(createdMessage == mockMessage)
+
+            assert(isClosedForWrite)
+            assert(isClosedForRead)
+            assert(totalBytesRead > 0L)
         }
-
-        assert(readChannel.isClosedForRead)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,7 +51,7 @@ fun VersionCatalogBuilder.kotlinx() {
 }
 
 fun VersionCatalogBuilder.ktor() {
-    val ktor = version("ktor", "2.1.0")
+    val ktor = version("ktor", "2.1.1")
 
     library("ktor-client-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef(ktor)
     library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef(ktor)


### PR DESCRIPTION
The reason the test was failing is that the channel wasn't read at all by the `MockEngine`, it does this now by calling `request.body.toByteArray()`.

I had to update ktor version because of [this](https://youtrack.jetbrains.com/issue/KTOR-2126) (`toByteArray()` would deadlock before 2.1.1).

I also replaced the string literal JSON with our serializable `DiscordMessage` model. This will be easier to maintain if the model changes because we'll get compile errors instead of failing tests.